### PR TITLE
Update wb_economy_recorder.py

### DIFF
--- a/src/zvt/recorders/wb/wb_economy_recorder.py
+++ b/src/zvt/recorders/wb/wb_economy_recorder.py
@@ -17,9 +17,13 @@ class WBEconomyRecorder(FixedCycleDataRecorder):
         date = None
         if start:
             date = f"{start.year}:{current_date().year}"
-        df = wb_api.get_economy_data(entity_id=entity.id, date=date)
-        df["name"] = entity.name
-        df_to_db(df=df, data_schema=self.data_schema, provider=self.provider, force_update=self.force_update)
+        try:
+            df = wb_api.get_economy_data(entity_id=entity.id, date=date)
+            df["name"] = entity.name
+            df_to_db(df=df, data_schema=self.data_schema, provider=self.provider, force_update=self.force_update)
+        # 一些地方获取不到数据会报错
+        except Exception as e:
+            print(e)s
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
一些地方获取数据会报错，比如第四个数据，entity.id=country_galaxy_6F
entity.name=IDA countries classified as fragile situations, excluding Sub-Saharan Africa 就会报错
The request returned no data:
url=http://api.worldbank.org/v2/country/6F/indicator/SP.POP.TOTL